### PR TITLE
Add basic Azure VM size selector web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Azure VM Size Selector
+
+This is a simple web application that suggests an Azure VM size based on the number of vCPUs, amount of memory, and deployment region specified by the user.
+
+## Running the app
+
+Serve the contents of this repository with any static web server. For example:
+
+```bash
+python3 -m http.server 8000
+```
+
+Then open `http://localhost:8000/index.html` in your browser.
+
+## Editing the VM data
+
+The list of available VM sizes is stored in `data/azure_vms.json`. Update this file to add or modify VM offerings.
+
+The matching logic resides in `js/selector.js`.

--- a/data/azure_vms.json
+++ b/data/azure_vms.json
@@ -1,0 +1,56 @@
+[
+  {
+    "name": "Standard_B1s",
+    "vcpus": 1,
+    "memory_gb": 1,
+    "regions": ["eastus", "westeurope", "westus"]
+  },
+  {
+    "name": "Standard_B2s",
+    "vcpus": 2,
+    "memory_gb": 4,
+    "regions": ["eastus", "westeurope"]
+  },
+  {
+    "name": "Standard_B2ms",
+    "vcpus": 2,
+    "memory_gb": 8,
+    "regions": ["eastus", "westus"]
+  },
+  {
+    "name": "Standard_D2s_v3",
+    "vcpus": 2,
+    "memory_gb": 8,
+    "regions": ["eastus", "westeurope", "centralus"]
+  },
+  {
+    "name": "Standard_D4s_v3",
+    "vcpus": 4,
+    "memory_gb": 16,
+    "regions": ["eastus", "westeurope", "centralus"]
+  },
+  {
+    "name": "Standard_E2s_v3",
+    "vcpus": 2,
+    "memory_gb": 16,
+    "regions": ["eastus", "westeurope"]
+  },
+  {
+    "name": "Standard_E4s_v3",
+    "vcpus": 4,
+    "memory_gb": 32,
+    "regions": ["eastus", "westeurope", "westus"]
+  },
+  {
+    "name": "Standard_F4s_v2",
+    "vcpus": 4,
+    "memory_gb": 8,
+    "regions": ["eastus", "westeurope", "centralus"]
+  },
+  {
+    "name": "Standard_F8s_v2",
+    "vcpus": 8,
+    "memory_gb": 16,
+    "regions": ["eastus", "westeurope", "westus"]
+  }
+]

--- a/index.html
+++ b/index.html
@@ -1,1 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Azure VM Size Selector</title>
+</head>
+<body>
+  <h1>Azure VM Size Selector</h1>
+  <form id="vmForm">
+    <label for="vcpu">vCPUs:</label>
+    <input type="number" id="vcpu" name="vcpu" min="1" required><br>
+    <label for="memory">Memory (GB):</label>
+    <input type="number" id="memory" name="memory" min="1" required><br>
+    <label for="region">Region:</label>
+    <input type="text" id="region" name="region" required><br>
+    <button type="submit">Find VM Size</button>
+  </form>
+  <div id="result" style="margin-top:20px;font-weight:bold;"></div>
 
+  <script src="js/selector.js"></script>
+</body>
+</html>

--- a/js/selector.js
+++ b/js/selector.js
@@ -1,0 +1,47 @@
+let vmData = [];
+
+async function loadVmData() {
+  const response = await fetch('data/azure_vms.json');
+  vmData = await response.json();
+}
+
+function findBestMatch(cpu, memory, region) {
+  let best = null;
+  let bestScore = Infinity;
+
+  for (const vm of vmData) {
+    if (!vm.regions.includes(region)) continue;
+
+    const cpuDiff = vm.vcpus - cpu;
+    const memDiff = vm.memory_gb - memory;
+
+    if (cpuDiff >= 0 && memDiff >= 0) {
+      const score = cpuDiff + memDiff;
+      if (score < bestScore) {
+        bestScore = score;
+        best = vm;
+      }
+    }
+  }
+  return best;
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  await loadVmData();
+  const form = document.getElementById('vmForm');
+  const resultDiv = document.getElementById('result');
+
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const cpu = parseFloat(form.vcpu.value);
+    const memory = parseFloat(form.memory.value);
+    const region = form.region.value.trim().toLowerCase();
+
+    const match = findBestMatch(cpu, memory, region);
+    if (match) {
+      resultDiv.textContent = `Suggested size: ${match.name} - ${match.vcpus} vCPUs, ${match.memory_gb} GB RAM`;
+    } else {
+      resultDiv.textContent = 'No matching VM size found.';
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add project README with run instructions
- populate `index.html` with a form for vCPU, memory, and region
- add sample VM size dataset
- implement client-side matching logic in `selector.js`

## Testing
- `git status --short`